### PR TITLE
Grow calendar updates and seed file change

### DIFF
--- a/client/src/components/GrowingCalendar/index.js
+++ b/client/src/components/GrowingCalendar/index.js
@@ -16,12 +16,17 @@ class GrowingCalendar extends React.Component{
   //variables common name and hardiness zone
 
   componentDidMount() {
-    //let commonName = "BASIL";
+    let hardinessZone = "10a"; //10a by default
+    
     let commonName1 = this.props.location.state.commonName;
     let commonName = commonName1.toUpperCase();
-    console.log(commonName);
-    let zone = "10a";
-    this.loadGrowCal(commonName,zone);
+    //console.log(commonName);
+    
+    let searchedZone = this.props.location.state.searchedZone;
+    if(searchedZone) {
+      hardinessZone = searchedZone;
+    }
+    this.loadGrowCal(commonName,hardinessZone);
   }
 
   loadGrowCal(commonName, zone) {
@@ -45,8 +50,49 @@ class GrowingCalendar extends React.Component{
   }
 
   setGrowCal(data) {
-    this.setState({growCal: data});
-      // $("#calendar").fullCalendar('rerenderEvents');
+    // We're not really using state for the calendar attributes
+    // this.setState({growCal: data});
+
+    // $("#calendar").fullCalendar('rerenderEvents');
+
+    let growData = data;
+    let commonName = this.props.location.state.commonName.toUpperCase();
+    let calendarAttrs = {
+      indoorStart : "",
+      indoorEnd : "",
+      directStart : "",
+      directEnd : "",
+      transplantStart : "",
+      transplantEnd : ""
+    };
+
+    // Step 1: Check how many growCal entries we got
+    console.log(commonName + "has " + growData.length + " growing calendar entries");
+
+    // Extract the start and end dates for each type of growing calendar
+    growData.forEach( (item) => {
+      let currentSowType = item.sowType.toLowerCase();
+      console.log("Found " + currentSowType + " calendar for " + commonName);
+      switch(currentSowType) {
+        case "indoor sow" :
+          calendarAttrs.indoorStart = moment(item.dtRangeStart).format("YYYY-MM-DD");
+          calendarAttrs.indoorEnd = moment(item.dtRangeEnd).format("YYYY-MM-DD");
+          break;
+        case "direct sow" :
+          calendarAttrs.directStart = moment(item.dtRangeStart).format("YYYY-MM-DD");
+          calendarAttrs.directEnd = moment(item.dtRangeEnd).format("YYYY-MM-DD");
+          break;
+        case "transplant" :
+          calendarAttrs.transplantStart = moment(item.dtRangeStart).format("YYYY-MM-DD");
+          calendarAttrs.transplantEnd = moment(item.dtRangeEnd).format("YYYY-MM-DD");
+          break;
+        default:
+          console.log("Unexpected sow type - " + currentSowType);
+      }
+    })
+
+
+
       $('#calendar').fullCalendar({
         defaultView: 'timelineYear',
         slotDuration: { months: 1 },
@@ -94,25 +140,31 @@ class GrowingCalendar extends React.Component{
           {
             id: "1",  //PlantID
             resourceId: "Transplant",  //sowType
-            start: "2019-02-15",  //dtRangeStart
-            end: "2019-03-28",  //dtRangeEnd
-            title: "2/15-3/28",  //month&Day of Range
+            start: calendarAttrs.transplantStart,
+            end: calendarAttrs.transplantEnd,
+            title: (moment(calendarAttrs.transplantStart).format("MM-DD")
+                    + " to " +
+                    moment(calendarAttrs.transplantEnd).format("MM-DD")),
             allDay: true
           },
           {
             id: "2",
             resourceId: "Indoor Sow",
-            start: "2019-01-04",
-            end: "2019-01-18",
-            title: "1/4-1/18",
+            start: calendarAttrs.indoorStart,
+            end: calendarAttrs.indoorEnd,
+            title: (moment(calendarAttrs.indoorStart).format("MM-DD")
+                    + " to " +
+                    moment(calendarAttrs.indoorEnd).format("MM-DD")),
             allDay: true
           },
           {
             id: "3",
             resourceId: "Direct Sow",
-            start: "2019-03-12",
-            end: "2019-04-06",
-            title: "3/12-4/06",
+            start: calendarAttrs.directStart,
+            end: calendarAttrs.directEnd,
+            title: (moment(calendarAttrs.directStart).format("MM-DD")
+                    + " to " +
+                    moment(calendarAttrs.directEnd).format("MM-DD")),
             allDay: true
           },
           {

--- a/client/src/components/PlantCards/index.js
+++ b/client/src/components/PlantCards/index.js
@@ -6,7 +6,7 @@ function PlantCard(props) {
     return(
         <Card className='medium'
             header={<CardTitle image={props.photo}>{props.commonName}</CardTitle>}
-            actions={<Link to={{pathname: `/plantdetail/${props.commonName.toLowerCase()}`, state: {id: props.id, commonName: props.commonName}}}>Detail</Link>}>
+            actions={<Link to={{pathname: `/plantdetail/${props.commonName.toLowerCase()}`, state: {id: props.id, commonName: props.commonName, searchedZone: props.searchedZone}}}>Detail</Link>}>
             Zone: {props.zones}<br/>
             Variety: {props.variety}<br/>
             Category: {props.category}

--- a/client/src/components/PlantCompanions/index.js
+++ b/client/src/components/PlantCompanions/index.js
@@ -17,7 +17,7 @@ class PlantCompanions extends React.Component {
 
     setItem(data) {
         if(data.compatable[0] === "" || data.compatable[0] === undefined) {
-            let data = " I have no friends...¯\_༼ ಥ ‿ ಥ ༽_/¯";
+            let data = " I have no friends...¯\\_༼ ಥ ‿ ಥ ༽_/¯";
             this.setState({item: data});
         }
         else{

--- a/scripts/seeds_plantingCalendar.js
+++ b/scripts/seeds_plantingCalendar.js
@@ -1,5 +1,6 @@
 const mongoose = require("mongoose");
 const db = require("../models");
+const moment = require("moment");
 
 // This file empties the Plants collection and inserts the plants below
 
@@ -13010,6 +13011,32 @@ const plantingCalendarSeed = [
     ]
   }
 ];
+
+/**
+ * Some sowCal objects have end dates occurring before start dates.
+ * For these, change the 'year' for the start date to the previous year.
+ */
+const runSeed = () => {
+  var inversions = 0;
+  for(let i = 0; i < plantingCalendarSeed.length; i++)
+  {
+    let sowCal = plantingCalendarSeed[i]["sowCal"];
+    for(let j = 0; j < sowCal.length; j++)
+    {
+      let startDate = sowCal[j]["dtRangeStart"];
+      let endDate = sowCal[j]["dtRangeEnd"];
+      if(moment(endDate).isBefore(moment(startDate))){
+        console.log(endDate + " " + startDate);
+        inversions++;
+        sowCal[j]["dtRangeStart"] = moment(startDate).subtract(1,"years").format("YYYY-MM-DD");
+      }
+    }
+  }
+
+  console.log(`Found and corrected ${inversions} objects with endDate before startDate!`);
+}
+
+runSeed();
 
 db.PlantingCalendar
   .deleteMany({})


### PR DESCRIPTION
1. Implemented the remaining functionality in grow calendar. Connected the user's hardiness zone to the grow calendar through this.props.location.state.  Also connected the grow calendar API results to the actual UI calendar properties.
2. Some entries in the grow calendar seed file had a start date that occurred AFTER end date. For these, moved the start date to the previous year, 
   e.g. {
        "zone": "7-8",
        "zones": ["7a", "7b", "8a", "8b"],
        "sowType": "Indoor Sow",
        **"dtRangeStart": "2019-12-21",**
        **"dtRangeEnd": "2019-01-04"**
      },
3. Fixed one lint warning in plantsCompanion.js. 